### PR TITLE
Catch`Invalid Date` error and display given value instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ In your view:
 ```html
 <p>
   Stimulus 1.0.0 was released
-  <time data-controller="timeago" data-timeago-datetime="2018-01-30 09:00"></time>.
+  <time data-controller="timeago" data-timeago-datetime="2018-01-30T09:00"></time>.
 </p>
 ```
 
@@ -41,13 +41,14 @@ In your view:
 
 | Attribute | Default | Description | Optional |
 | --------- | ------- | ----------- | -------- |
-| `data-timeago-datetime` | `undefined` | String that can be parsed by Date.parse(). | ❌ |
+| `data-timeago-datetime` | `undefined` | String that can be parsed by `Date.parse()`. | ❌ |
 | `data-timeago-refresh-interval` | `undefined` | Interval in milliseconds to reload the distance. | ✅ |
 | `data-timeago-include-seconds` | `false` | Distances less than a minute are more detailed | ✅ |
 | `data-timeago-add-suffix` | `false` | Result specifies if now is earlier or later than the passed date | ✅ |
 
 `includeSeconds` and `addSuffix` are the options of the [date-fns/formatDistanceToNow](https://date-fns.org/v2.2.1/docs/formatDistanceToNow) method.
 
+If the datetime string passed via `data-timeago-datetime` is not parseable by `Date.parse()` it will display the given value instead.
 
 ## Extending Controller
 

--- a/index.html
+++ b/index.html
@@ -92,7 +92,7 @@
         Stimulus 1.0.0 was released
         <time
           data-controller="timeago"
-          data-timeago-datetime="2018-01-30 09:00"
+          data-timeago-datetime="2018-01-30T09:00"
           data-timeago-refresh-interval="1000"
           data-timeago-include-seconds=""
           data-timeago-add-suffix=""

--- a/src/index.js
+++ b/src/index.js
@@ -19,29 +19,23 @@ export default class extends Controller {
   }
 
   load () {
-    const date = this.data.get('datetime')
+    const datetime = this.data.get('datetime')
+    const date = Date.parse(datetime)
     const options = {
       includeSeconds: this.data.has('includeSeconds') || false,
       addSuffix: this.data.has('addSuffix') || false
     }
 
-    let formattedDate
-    try {
-      formattedDate = formatDistanceToNow(Date.parse(date), options)
-    } catch (e) {
-      if (e instanceof RangeError) {
-        formattedDate = date
-        this.isValid = false
-        console.error(
-          `Value given in "data-timeago-datetime" is not a valid date (${date}). Please provide a ISO 8601 compatible datetime string. Displaying given value instead.`
-        )
-      } else {
-        throw e
-      }
+    if (Number.isNaN(date)) {
+      this.isValid = false
+
+      console.error(
+        `Value given in 'data-timeago-datetime' is not a valid date (${datetime}). Please provide a ISO 8601 compatible datetime string. Displaying given value instead.`
+      )
     }
 
-    this.element.dateTime = date
-    this.element.innerHTML = formattedDate
+    this.element.dateTime = datetime
+    this.element.innerHTML = this.isValid ? formatDistanceToNow(date, options) : datetime
   }
 
   startRefreshing () {

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,9 @@ import { Controller } from 'stimulus'
 import formatDistanceToNow from 'date-fns/formatDistanceToNow'
 
 export default class extends Controller {
-  static isValid = true
+  initialize () {
+    this.isValid = true
+  }
 
   connect () {
     this.load()

--- a/src/index.js
+++ b/src/index.js
@@ -2,10 +2,12 @@ import { Controller } from 'stimulus'
 import formatDistanceToNow from 'date-fns/formatDistanceToNow'
 
 export default class extends Controller {
+  static isValid = true
+
   connect () {
     this.load()
 
-    if (this.data.has('refreshInterval')) {
+    if (this.data.has('refreshInterval') && this.isValid) {
       this.startRefreshing()
     }
   }
@@ -21,8 +23,23 @@ export default class extends Controller {
       addSuffix: this.data.has('addSuffix') || false
     }
 
+    let formattedDate
+    try {
+      formattedDate = formatDistanceToNow(Date.parse(date), options)
+    } catch (e) {
+      if (e instanceof RangeError) {
+        formattedDate = date
+        this.isValid = false
+        console.error(
+          `Value given in "data-timeago-datetime" is not a valid date (${date}). Please provide a ISO 8601 compatible datetime string. Displaying given value instead.`
+        )
+      } else {
+        throw e
+      }
+    }
+
     this.element.dateTime = date
-    this.element.innerHTML = formatDistanceToNow(Date.parse(date), options)
+    this.element.innerHTML = formattedDate
   }
 
   startRefreshing () {


### PR DESCRIPTION
Hey @guillaumebriday,

It seems like that some browsers see `2018-01-30 09:00` as an invalid date. 
Technically speaking it's not a valid ISO 8601 timestamp. But it seems that some browsers are somewhat generous to treat it as a valid timestamp.

However, this PR fixes the timestamp and shows the given input on a validation error! 😊 