### PR TITLE
Allow to disable options using "false" or "0"

### DIFF
--- a/index.html
+++ b/index.html
@@ -135,7 +135,8 @@
         <time
           data-controller="timeago"
           data-timeago-datetime-value="2018-01-30T09:00"
-          data-timeago-add-suffix-value=""
+          data-timeago-include-seconds-value="true"
+          data-timeago-add-suffix-value="true"
         ></time
         >.
       </section>

--- a/specs/index.test.ts
+++ b/specs/index.test.ts
@@ -54,7 +54,7 @@ describe('#load', () => {
       <time
         data-controller="timeago"
         data-timeago-datetime-value="${lastMonth.toISOString()}"
-        data-timeago-add-suffix-value=""
+        data-timeago-add-suffix-value="true"
       ></time>.
     `
 
@@ -70,7 +70,7 @@ describe('#load', () => {
       <time
         data-controller="timeago"
         data-timeago-datetime-value="${fewSecondsAgo.toISOString()}"
-        data-timeago-include-seconds-value=""
+        data-timeago-include-seconds-value="true"
       ></time>.
     `
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,8 +8,8 @@ export default class extends Controller {
 
   hasRefreshIntervalValue: boolean
   datetimeValue: string
-  hasAddSuffixValue: boolean
-  hasIncludeSecondsValue: boolean
+  addSuffixValue: boolean
+  includeSecondsValue: boolean
   refreshIntervalValue: number
 
   static values = {
@@ -39,8 +39,8 @@ export default class extends Controller {
     const datetime: string = this.datetimeValue
     const date: number = Date.parse(datetime)
     const options: object = {
-      includeSeconds: this.hasIncludeSecondsValue,
-      addSuffix: this.hasAddSuffixValue,
+      includeSeconds: this.includeSecondsValue,
+      addSuffix: this.addSuffixValue,
       locale: this.locale
     }
 


### PR DESCRIPTION
`data-add-suffix-value` and `data-include-seconds-value` now can be disabled using the values `false` or `0`.

There is no breaking change since the missing parameter results in a `false` value.
https://stimulus.hotwired.dev/reference/values#getters

Fixes https://github.com/stimulus-components/stimulus-timeago/issues/7